### PR TITLE
Refactor task actions to use forms instead of onclick events

### DIFF
--- a/src/views/tasks.pug
+++ b/src/views/tasks.pug
@@ -52,9 +52,11 @@ html
                       path(d='M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z')
                   ul.dropdown-menu(aria-labelledby='dropdownMenu2')
                     li
-                      button.dropdown-item(type='button', onclick="location.href='/api/tasks/update/' + task.id") Edit
+                      form(action='/api/tasks/update/' + task.id, method='POST')
+                        button.dropdown-item(type='submit') Edit
                     li
-                      button.dropdown-item.text-danger(type='button', onclick="location.href='/api/tasks/delete/' + task.id") Delete
+                      form(action='/api/tasks/delete/' + task.id, method='POST')
+                        button.dropdown-item.text-danger(type='submit') Delete
           form(action='/api/tasks/add', method='POST')
             .form-group
               label(for='taskName') Task Name


### PR DESCRIPTION
Refactor task actions to use forms instead of onclick events